### PR TITLE
Added support for Serialization by System.Text.Json

### DIFF
--- a/Camille/gen/GeneratedClasses.cs.dt
+++ b/Camille/gen/GeneratedClasses.cs.dt
@@ -225,14 +225,14 @@ namespace MingweiSamuel.Camille.{{= dotUtils.normalizeEndpointName(endpoint) }}
         /// </summary>
 {{?}}
         {{= dotUtils.formatJsonProperty(propKey) }}
-        public readonly {{= dotUtils.stringifyType(prop) }} {{= name }};
+        public {{= dotUtils.stringifyType(prop) }} {{= name }} { get; }
 {{
         }
 }}
 
         /// <summary>Contains any extra JSON properties that did not map to fields.</summary>
         [JsonExtensionData]
-        public readonly Dictionary<string, JToken> _AdditionalProperties = new Dictionary<string, JToken>();
+        public Dictionary<string, object> _AdditionalProperties { get; } = new Dictionary<string, object>();
 
         public override string ToString()
         {


### PR DESCRIPTION
PR for issue #12

I changed the fields on the data objects to properties as well as changing the JObject into a normal object.
I am open for discussion on the JObject to object change, as it isn't the most graceful way but it doesn't break the tests. Nor does it break the Json serialization.