### PR TITLE
Update DTOs to use nullability

### DIFF
--- a/Camille/gen/DataClasses.cs.dt
+++ b/Camille/gen/DataClasses.cs.dt
@@ -28,42 +28,48 @@ using JsonExtensionDataAttribute = System.Text.Json.Serialization.JsonExtensionD
 
 {{/* DTOs */}}
 {{
-    let schemas = spec.components.schemas;
-    for (let schemaKey of Object.keys(schemas)) {
+    const schemas = spec.components.schemas;
+    for (const schemaKey of Object.keys(schemas)) {
         if ('Error'  === schemaKey) {
             continue;
         }
-        let schemaSplit = schemaKey.split('.');
-        let endpoint = schemaSplit[0];
-        if ('lol-static-data-v3' === endpoint) { continue; }
-        let schemaName = dotUtils.normalizeSchemaName(schemaSplit[1]);
-        let schema = schemas[schemaKey];
-        let props = schema.properties;
+        const schemaSplit = schemaKey.split('.');
+        const endpoint = schemaSplit[0];
+        const schemaName = dotUtils.normalizeSchemaName(schemaSplit[1]);
+        const schema = schemas[schemaKey];
+        const props = schema.properties;
+
+        const fields = Object.entries(props).map(([ propKey, prop ]) => {
+            const name = dotUtils.normalizePropName(propKey, schemaName, prop);
+            const type = dotUtils.stringifyType(prop)
+                + (schema.required && schema.required.includes(propKey) ? '' : '?');
+            return { propKey, name, type, description: prop.description };
+        }).sortBy(({ name }) => name);
 }}
 // {{= endpoint }}
 namespace MingweiSamuel.Camille.{{= dotUtils.normalizeEndpointName(endpoint) }}
 {
-#nullable disable
     /// <summary>
     /// {{= schemaName }} data object. This class is automatically generated.<para />
     /// {{= schema.description || '' }}
     /// </summary>
     public class {{= schemaName }}
     {
-        public {{= schemaName }}()
-        {}
+#nullable disable
+        public {{= schemaName }}() {}
+#nullable restore
+
 {{
-        for (let [ propKey, prop ] of Object.entries(props))
+        for (const { propKey, name, type, description } of fields)
         {
-            let name = dotUtils.normalizePropName(propKey, schemaName, prop);
 }}
-{{? prop.description }}
+{{? description }}
         /// <summary>
-        /// {{= prop.description.split('\n').map(x => x.trim()).join('<para />\r\n        /// ') }}
+        /// {{= description.split('\n').map(x => x.trim()).join('<para />\r\n        /// ') }}
         /// </summary>
 {{?}}
         {{= dotUtils.formatJsonProperty(propKey) }}
-        public {{= dotUtils.stringifyType(prop) }} {{= name }} { get; set; }
+        public {{= type }} {{= name }} { get; set; }
 {{
         }
 }}
@@ -87,7 +93,6 @@ namespace MingweiSamuel.Camille.{{= dotUtils.normalizeEndpointName(endpoint) }}
                 + "_AdditionalProperties: {" + string.Join(", ", _AdditionalProperties.Select(kv => $"\"{kv.Key}\": {kv.Value}")) + "})";
         }
     }
-#nullable restore
 }
 
 {{

--- a/Camille/gen/EndpointMethods.cs.dt
+++ b/Camille/gen/EndpointMethods.cs.dt
@@ -51,7 +51,7 @@ namespace MingweiSamuel.Camille
 
             let jsonInfo = get.responses['200'].content['application/json'];
             let returnType = dotUtils.stringifyType(jsonInfo.schema, endpoint);
-            if ('int' !== returnType) returnType += '?'; /* HACK. */
+            if (get['x-nullable-404']) returnType += '?';
 
             /* Cases if not rate limited. */
             let rateLimitExcluded = get['x-app-rate-limit-excluded'] ? true : false;
@@ -86,8 +86,9 @@ namespace MingweiSamuel.Camille
                     for (let param of paramList)
                     {
                         argBuilder.push(', ',
-                            dotUtils.stringifyType(param.schema, endpoint, !required),
-                            ' ', param.name);
+                            dotUtils.stringifyType(param.schema, endpoint),
+                            required ? ' ' : '? ',
+                            param.name);
                         if (!required)
                             argBuilder.push(' = null');
                     }

--- a/Camille/gen/dotUtils.js
+++ b/Camille/gen/dotUtils.js
@@ -51,7 +51,7 @@ function normalizePropName(propName, schemaName, value) {
   return name;
 }
 
-function stringifyType(prop, endpoint = null, nullable = false) {
+function stringifyType(prop, endpoint = null) {
   if (prop.anyOf) {
     prop = prop.anyOf[0];
   }
@@ -61,25 +61,20 @@ function stringifyType(prop, endpoint = null, nullable = false) {
     return (!endpoint ? '' : endpoint + '.') +
       normalizeSchemaName(refType.slice(refType.indexOf('.') + 1));
   }
-  var qm = nullable ? '?' : '';
   var enumName = prop['x-enum'];
   if (enumName !== undefined) {
-    if (prop.type === 'array') {
-      return normalizePropName(enumName, 'placeholder', '') + '[]' + qm;
-    } else {
-      return normalizePropName(enumName, 'placeholder', '') + qm;
-    }
+    return normalizePropName(enumName, 'placeholder', '') + (prop.type === 'array' ? '[]' : '');
   }
 
   switch (prop.type) {
-    case 'boolean': return 'bool' + qm;
-    case 'integer': return ('int32' === prop.format ? 'int' : 'long') + qm;
-    case 'number': return prop.format + qm;
-    case 'array': return stringifyType(prop.items, endpoint) + '[]' + qm;
+    case 'boolean': return 'bool';
+    case 'integer': return ('int32' === prop.format ? 'int' : 'long');
+    case 'number': return prop.format;
+    case 'array': return stringifyType(prop.items, endpoint) + '[]';
     case 'object':
       return 'IDictionary<' + stringifyType(prop['x-key'], endpoint) + ', ' +
-        stringifyType(prop.additionalProperties, endpoint) + '>' + qm;
-    default: return prop.type + qm;
+        stringifyType(prop.additionalProperties, endpoint) + '>';
+    default: return prop.type;
   }
 }
 


### PR DESCRIPTION
Updates DTOs to use C# 8 `?` nullability. Also sorts the fields by name.

Concerns: depends on newtonsoft / system.text.json respecting the nullability. Actual constructors don't enforce it.

@RyadaProductions Any thoughts? If you'd like to review larger changes