### PR TITLE
Fix missing gameQueueConfigId from SpectatorV4 in enumTable

### DIFF
--- a/srcgen/dotUtils.js
+++ b/srcgen/dotUtils.js
@@ -1,14 +1,15 @@
 ﻿const enumTable = {
-  'champion':   'Camille.Enums.Champion',
-  'division':   'Camille.Enums.Division',
-  'gameMode':   'Camille.Enums.GameMode',
-  'gameType':   'Camille.Enums.GameType',
-  'locale':     'Camille.Enums.Locale',
-  'map':        'Camille.Enums.Map',
-  'queueType':  'Camille.Enums.QueueType',
-  'tier':       'Camille.Enums.Tier',
+  'champion':           'Camille.Enums.Champion',
+  'division':           'Camille.Enums.Division',
+  'gameMode':           'Camille.Enums.GameMode',
+  'gameType':           'Camille.Enums.GameType',
+  'locale':             'Camille.Enums.Locale',
+  'map':                'Camille.Enums.Map',
+  'gameQueueConfigId':  'Camille.Enums.Queue',
+  'queueType':          'Camille.Enums.QueueType',
+  'tier':               'Camille.Enums.Tier',
 
-  'team':       'Camille.RiotGames.Enums.Team',
+  'team':               'Camille.RiotGames.Enums.Team',
 };
 
 function capitalize(input) {


### PR DESCRIPTION
`gameQueueConfigId` from the `SpectatorV4` endpoint is not serialized to `Camille.Enum.Queue` anymore since 4738f47aa0e4ec3b9de8f91c044f0e6dda0cd9b6.

If I read the code correctly this should fix it.