### PR TITLE
Add RANKED_TFT_PAIRS QueueType

### DIFF
--- a/Camille.Enums/src/QueueType.cs
+++ b/Camille.Enums/src/QueueType.cs
@@ -22,5 +22,7 @@ namespace Camille.Enums
         RANKED_TFT = 1100,
         /// <summary>Ranked Teamfight Tactics, Hyper Roll game mode.</summary>
         RANKED_TFT_TURBO = 1130,
+        /// <summary>Ranked Teamfight Tactics, Double Up game mode.</summary>
+        RANKED_TFT_PAIRS = 1150,
     }
 }


### PR DESCRIPTION
Fixes current JSON serialization issues due to missing Enum member.

Future ideas:
I have also added a queueTypes.json MingweiSamuel/riotapi-schema#29 and request to add to official docs in RiotGames/developer-relations#574, but am not confident enough to convert this Enum to be auto generated.

Maybe we could also add a UNKNOWN enum member to types that dynamically change with games updates as fallback, so library versions without the new specific member could still work properly for older games modes etc instead of throwing JsonException due to serialization problems?