### PR TITLE
Added package manager command with -IncludePrerelease

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ Data classes are automatically generated from the
 
 ## Installation
 
-[Install via NuGet](https://www.nuget.org/packages?sortby=created-desc&q=Camille&prerel=True) (`Camille.RiotGames`).
+[Install via NuGet](https://www.nuget.org/packages?sortby=created-desc&q=Camille&prerel=True) (`Camille.RiotGames`). 
+
+Type the following the the package manager console:
+
+    Install-Package Camille.RiotGames -IncludePrerelease
 
 ## Usage
 


### PR DESCRIPTION
I accidentally installed an older version since it wasn't clear enough for me that one had to include prereleases. I think adding the command (which pretty much all NuGet packages have in their readme's) will make it more clear that one must include prereleases for this package.

Camille.Lcu is [working great](https://github.com/mikaeldui/ChampionMastery.GG-winui/blob/main/MikaelDui.ChampionMasteryGg.WinUI/Helpers/LcuHelper.cs) btw.