### PR TITLE
Floating version references in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,17 @@ Data classes are automatically generated from the
 
 [Install via NuGet](https://www.nuget.org/packages?sortby=created-desc&q=Camille&prerel=True) (`Camille.RiotGames`). 
 
-Type the following in the package manager console:
+Type the following in the **Package Manager** console:
 
     Install-Package Camille.RiotGames -IncludePrerelease
     
-Or use the .NET CLI:
+Or use the **.NET CLI** to reference the **latest nightly build**:
 
-    dotnet add package Camille.RiotGames --prerelease
+    dotnet add package Camille.RiotGames --version 3.0.0-nightly-*
+    
+You can also reference the **latest nightly build** using a **PackageReference**:
+
+    <PackageReference Include="Camille.RiotGames" Version="3.0.0-nightly-*" />
 
 ## Usage
 


### PR DESCRIPTION
I think adding [floating version][nuget-floating-version-resolutions] examples is good, since there's no reason for someone to use an old build that's no longer complying to the schemas.

Since [`Install-Package` doesn't seem to do floating versions](https://github.com/NuGet/docs.microsoft.com-nuget/issues/2186) the [`PackageReference`][packagereference-floating-versions] is needed for projects that aren't compatible with [`dotnet add package`][dotnet-add-package], for example, Win UI 3 projects (currently) and maybe .NET Framework projects.

References:
 - [dotnet add package command - .NET CLI | Microsoft Docs][dotnet-add-package]
 - [Floating versions | NuGet PackageReference in project files | Microsoft Docs][packagereference-floating-versions]
 - [Floating version resolutions | Nuget Package Version Reference | Microsoft Docs][nuget-floating-version-resolutions]
 - [Semantic Versioning 2.0.0](https://semver.org/)

[dotnet-add-package]: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-add-package "dotnet add package command - .NET CLI | Microsoft Docs"
[nuget-floating-version-resolutions]: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#floating-version-resolutions "Floating version resolutions | Nuget Package Version Reference | Microsoft Docs"
[packagereference-floating-versions]: https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#floating-versions "Floating versions | NuGet PackageReference in project files | Microsoft Docs"