### PR TITLE
SemVer 2.0.0 compliant version for nightly builds

### DIFF
--- a/SetEnv.ps1
+++ b/SetEnv.ps1
@@ -38,7 +38,7 @@ If ($VERSION_TAG -Ne $REPO_TAG -Or -Not ($env:CAMI_VERSION -As [Version])) {
     $ver = $ver -Join '.'
     # Append date for ordering, and include commit ID.
     $date = (Get-Date).ToUniversalTime().ToString('o').Substring(0, 10)
-    $env:CAMI_VERSION = "$ver-nightly-$date-$(git rev-parse --short=10 HEAD)"
+    $env:CAMI_VERSION = "$ver-nightly.$date+$(git rev-parse --short=10 HEAD)"
 }
 
 # Set CAMI_SPEC_HASH


### PR DESCRIPTION
[SemVer 2.0.0](https://semver.org) (used for NuGet packages):

> $9: A pre-release version MAY be denoted by appending a hyphen and a series of **dot separated** identifiers immediately following the patch version.
> $10: Build metadata MAY be denoted by appending a **plus sign** and a series of dot separated identifiers immediately following the patch or pre-release version.

Moving the build date to build metadata would prevent packages from being pushed to repos and downloaded by NuGet clients. Thus it must to be on the left side of the plus sign in order to give the package precedence, if there are no other version increments. It also makes sense to use the date as version for a nightly build.

**Current** version example: `3.0.0-nightly-2021-12-30-6d67c5d9bd` (❌ non-compliant)
**New** version example: `3.0.0-nightly.2021-12-30+6d67c5d9bd` (✅ compliant)

This was initially discussed in #70.