### PR TITLE
Added Target Framework net6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,10 @@ jobs:
           Write-Output "CAMI_VERSION=$env:CAMI_VERSION"     | Out-File -Append -FilePath $env:GITHUB_ENV
           Write-Output "CAMI_SPEC_HASH=$env:CAMI_SPEC_HASH" | Out-File -Append -FilePath $env:GITHUB_ENV
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/Camille.Core.Test/Camille.Core.Test.csproj
+++ b/Camille.Core.Test/Camille.Core.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Camille.Core/Camille.Core.csproj
+++ b/Camille.Core/Camille.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\common.csproj.xml" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net45;netstandard2.1;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;net45;netstandard2.1;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <PackageId>Camille.Core</PackageId>
     <RootNamespace>Camille.Core</RootNamespace>
     <Description>Core utilities for Camille packages.</Description>

--- a/Camille.Enums.Test/Camille.Enums.Test.csproj
+++ b/Camille.Enums.Test/Camille.Enums.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Camille.Enums/Camille.Enums.csproj
+++ b/Camille.Enums/Camille.Enums.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\common.csproj.xml" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net45;netcoreapp2.1;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;net45;netcoreapp2.1;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <PackageId>Camille.Enums</PackageId>
     <RootNamespace>Camille.Enums</RootNamespace>
     <Description>Enums for League of Legends and other Riot Games games.</Description>

--- a/Camille.Lcu.Test/Camille.Lcu.Test.csproj
+++ b/Camille.Lcu.Test/Camille.Lcu.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Camille.Lcu/Camille.Lcu.csproj
+++ b/Camille.Lcu/Camille.Lcu.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\common.csproj.xml" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <PackageId>Camille.Lcu</PackageId>
     <RootNamespace>Camille.Lcu</RootNamespace>
     <Description>League of Legends Client Update API Library.</Description>

--- a/Camille.LolGame.Test/Camille.LolGame.Test.csproj
+++ b/Camille.LolGame.Test/Camille.LolGame.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Camille.LolGame/Camille.LolGame.csproj
+++ b/Camille.LolGame/Camille.LolGame.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\common.csproj.xml" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <PackageId>Camille.LolGame</PackageId>
     <RootNamespace>Camille.LolGame</RootNamespace>
     <Description>League of Legends Live (In-Game) Client Data API library</Description>

--- a/Camille.RiotGames.Test/Camille.RiotGames.Test.csproj
+++ b/Camille.RiotGames.Test/Camille.RiotGames.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Camille.RiotGames/Camille.RiotGames.csproj
+++ b/Camille.RiotGames/Camille.RiotGames.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\common.csproj.xml" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net45;netcoreapp2.1;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;net45;netcoreapp2.1;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <PackageId>Camille.RiotGames</PackageId>
     <RootNamespace>Camille.RiotGames</RootNamespace>
     <Description>Riot Games API library. Fully rate limited, automatic retrying, thread-safe. Up-to-date nightlies.</Description>

--- a/common.csproj.xml
+++ b/common.csproj.xml
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <!-- Include RiotCertificateUtils for LCU or In-Game APIs. -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.0' Or '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.0' Or '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'">
     <DefineConstants>$(DefineConstants);INCLUDE_RIOTCERTIFICATEUTILS</DefineConstants>
   </PropertyGroup>
 
@@ -69,7 +69,7 @@
     <DefineConstants>$(DefineConstants);USE_NEWTONSOFT</DefineConstants>
   </PropertyGroup>
   <!-- Camille using System.Text.Json. -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'">
     <DefineConstants>$(DefineConstants);USE_SYSTEXTJSON</DefineConstants>
   </PropertyGroup>
   <!--
@@ -78,7 +78,7 @@
     HttpContent.ReadAsStringAsync with CancellationToken in net5.0.
     https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpcontent.readasstringasync?view=net-5.0#System_Net_Http_HttpContent_ReadAsStringAsync_System_Threading_CancellationToken_
   -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'">
     <DefineConstants>$(DefineConstants);USE_HTTPREQUESTMESSAGE_OPTIONS;USE_HTTPCONTENT_READASSTRINGASYNC_CANCELLATIONTOKEN</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
- [x]  Added `net6.0` to all `TargetFrameworks`.
- [x]  Added `actions/setup-dotnet` to `ci.yml` since `windows-2019` doesn't come with `6.0.x` pre-installed right now.
- [x] Added `net6.0` to `common.csproj.xml` where `net5.0` is. 
- [ ] Not sure about `DefineConstants`?

I've [tested](https://mikaeldui.github.io/champion-mastery/) `Camille.Enums` with Blazor WebAssembly and it works great. But I can relate to #58.