### PR TITLE
Bump MingweiSamuel.TokenBucket from 1.0.1 to 1.0.2

### DIFF
--- a/src/Camille.Lcu/Camille.Lcu.csproj
+++ b/src/Camille.Lcu/Camille.Lcu.csproj
@@ -7,7 +7,7 @@
     <Description>League of Legends Client Update API Library.</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MingweiSamuel.TokenBucket" Version="1.0.1" />
+    <PackageReference Include="MingweiSamuel.TokenBucket" Version="1.0.2" />
     <ProjectReference Include="$(SolutionDir)src\Camille.Core\Camille.Core.csproj" />
     <ProjectReference Include="$(SolutionDir)src\Camille.Enums\Camille.Enums.csproj" />
   </ItemGroup>

--- a/src/Camille.LolGame/Camille.LolGame.csproj
+++ b/src/Camille.LolGame/Camille.LolGame.csproj
@@ -7,7 +7,7 @@
     <Description>League of Legends Live (In-Game) Client Data API library</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MingweiSamuel.TokenBucket" Version="1.0.1" />
+    <PackageReference Include="MingweiSamuel.TokenBucket" Version="1.0.2" />
     <ProjectReference Include="$(SolutionDir)src\Camille.Core\Camille.Core.csproj" />
     <ProjectReference Include="$(SolutionDir)src\Camille.Enums\Camille.Enums.csproj" />
   </ItemGroup>

--- a/src/Camille.RiotGames/Camille.RiotGames.csproj
+++ b/src/Camille.RiotGames/Camille.RiotGames.csproj
@@ -8,7 +8,7 @@
     <Description>Riot Games API library. Fully rate limited, automatic retrying, thread-safe. Up-to-date nightlies.</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MingweiSamuel.TokenBucket" Version="1.0.1" />
+    <PackageReference Include="MingweiSamuel.TokenBucket" Version="1.0.2" />
     <ProjectReference Include="$(SolutionDir)src\Camille.Core\Camille.Core.csproj" />
     <ProjectReference Include="$(SolutionDir)src\Camille.Enums\Camille.Enums.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Removes the `NETStandard.Library (>= 1.6.1)` or `Microsoft.NETCore.App (>= 1.0.5)` dependency on modern frameworks, which carry a bunch of unnecessary packages.

Ref: https://github.com/MingweiSamuel/TokenBucket/pull/1