### PR TITLE
Add custom domain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,6 @@ var riotApi = RiotGamesApi.NewInstance(
         // ...
     }.Build()
 );
-// OR with a proxy server
-var riotApi = RiotGamesApi.NewInstance(
-    new RiotGamesApiConfig.Builder("")
-    {
-        // ...
-        ApiURL = "proxy.myexample.app",
-    }.Build()
-);
-// Which will send requests like https://proxy.myexample.app/lol/summoner/v4/summoners/by-name/NAME?region=NA1
 ```
 You can find all configuration options [here](https://github.com/MingweiSamuel/Camille/blob/gh-pages/v/3.x.x/_gen/Camille.RiotGames/RiotGamesApiConfig.cs).
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ using Camille.RiotGames;
 var riotApi = RiotGamesApi.NewInstance("RGAPI-12345678-abcd-1234-abcd-123456abcdef");
 // OR
 var riotApi = RiotGamesApi.NewInstance(
-    new RiotApiConfig.Builder("RGAPI-12345678-abcd-1234-abcd-123456abcdef")
+    new RiotGamesApiConfig.Builder("RGAPI-12345678-abcd-1234-abcd-123456abcdef")
     {
         MaxConcurrentRequests = 200,
         Retries = 10,
@@ -73,7 +73,7 @@ foreach (var summoner in summoners)
     Console.WriteLine($"{summoner.Name}'s Top 10 Champs:");
 
     var masteries =
-        riotApi.ChampionMasteryV4().GetAllChampionMasteries(PlatformRoute.NA1, summoner.Id);
+        riotApi.ChampionMasteryV4().GetAllChampionMasteriesByPUUID(PlatformRoute.NA1, summoner.Puuid);
 
     for (var i = 0; i < 10; i++)
     {

--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ var riotApi = RiotGamesApi.NewInstance(
         // ...
     }.Build()
 );
+// OR with a proxy server
+var riotApi = RiotGamesApi.NewInstance(
+    new RiotGamesApiConfig.Builder("")
+    {
+        // ...
+        ApiURL = "proxy.myexample.app",
+    }.Build()
+);
+// Which will send requests like https://proxy.myexample.app/lol/summoner/v4/summoners/by-name/NAME?region=NA1
 ```
 You can find all configuration options [here](https://github.com/MingweiSamuel/Camille/blob/gh-pages/v/3.x.x/_gen/Camille.RiotGames/RiotGamesApiConfig.cs).
 

--- a/src/Camille.RiotGames/Camille.RiotGames.csproj
+++ b/src/Camille.RiotGames/Camille.RiotGames.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\common.csproj.xml" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net45;net461;netstandard2.1;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net45;net461;netstandard2.1;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <PackageId>Camille.RiotGames</PackageId>
     <RootNamespace>Camille.RiotGames</RootNamespace>
     <Description>Riot Games API library. Fully rate limited, automatic retrying, thread-safe. Up-to-date nightlies.</Description>
@@ -15,6 +15,18 @@
 
   <ItemGroup>
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Web" Condition="'$(TargetFramework)' == 'net45'">
+      <HintPath>$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net45\1.0.3\build\.NETFramework\v4.5\System.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web" Condition="'$(TargetFramework)' == 'net461'">
+      <HintPath>$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.3\build\.NETFramework\v4.6.1\System.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web" Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+      <HintPath>$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Web.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
   <Target Name="DownloadTemplateData" BeforeTargets="DownloadTemplateDataTrigger">

--- a/src/Camille.RiotGames/gen/RiotGamesApiConfig.cs.dt
+++ b/src/Camille.RiotGames/gen/RiotGamesApiConfig.cs.dt
@@ -6,20 +6,10 @@
 // Do not directly edit.
 // Generated on {{= (new Date).toISOString() }}
 using System;
+using Camille.RiotGames.Enums;
 
 namespace Camille.RiotGames
 {
-    public enum RegionConfig
-    {
-        /// <summary>The Region should be in the URL, as a subdomain</summary>
-        inUrlAsSubdomain,
-        /// <summary>The Region should be in the URL, as a query parameter</summary>
-        inUrlAsRegionQueryParameter,
-        /// <summary>The Region should be a header instead of in the URL</summary>
-        /// <seealso cref="RiotGamesApiConfig.RegionHeaderKey"/>
-        inHeader,
-    }
-
     public interface IRiotGamesApiConfig
     {
 {{

--- a/src/Camille.RiotGames/gen/RiotGamesApiConfig.cs.dt
+++ b/src/Camille.RiotGames/gen/RiotGamesApiConfig.cs.dt
@@ -9,6 +9,17 @@ using System;
 
 namespace Camille.RiotGames
 {
+    public enum RegionConfig
+    {
+        /// <summary>The Region should be in the URL, as a subdomain</summary>
+        inUrlAsSubdomain,
+        /// <summary>The Region should be in the URL, as a query parameter</summary>
+        inUrlAsRegionQueryParameter,
+        /// <summary>The Region should be a header instead of in the URL</summary>
+        /// <seealso cref="RiotGamesApiConfig.RegionHeaderKey"/>
+        inHeader,
+    }
+
     public interface IRiotGamesApiConfig
     {
 {{

--- a/src/Camille.RiotGames/gen/configspec.json
+++ b/src/Camille.RiotGames/gen/configspec.json
@@ -5,8 +5,18 @@
   },
   "apiUrl": {
     "type": "string",
-    "desc": "URL to call for the Riot Games API.",
-    "val": "\"api.riotgames.com\""
+    "desc": "URL to call for the Riot Games API. Include {0} for the region, if you want it in the URL - Not necessary for RegionConfig.inUrlAsRegionQueryParameter.",
+    "val": "\"{0}.api.riotgames.com\""
+  },
+  "apiCallRegionConfig": {
+    "type": "RegionConfig",
+    "desc": "How the API call should include the region.",
+    "val": "RegionConfig.inUrlAsSubdomain"
+  },
+  "regionHeaderKey": {
+    "type": "string",
+    "desc": "The header key to use for the region. Only used if RegionConfig is set to inHeader.",
+    "val": "\"Riot-Region\""
   },
   "maxConcurrentRequests": {
     "type": "int",

--- a/src/Camille.RiotGames/gen/configspec.json
+++ b/src/Camille.RiotGames/gen/configspec.json
@@ -3,7 +3,7 @@
     "type": "string",
     "desc": "Riot Games API key."
   },
-  "apiURL": {
+  "apiUrl": {
     "type": "string",
     "desc": "URL to call for the Riot Games API.",
     "val": "\"api.riotgames.com\""

--- a/src/Camille.RiotGames/gen/configspec.json
+++ b/src/Camille.RiotGames/gen/configspec.json
@@ -3,6 +3,16 @@
     "type": "string",
     "desc": "Riot Games API key."
   },
+  "apiURL": {
+    "type": "string",
+    "desc": "URL to call for the Riot Games API.",
+    "val": "\"api.riotgames.com\""
+  },
+  "apiRegionAsSubdomain": {
+    "type": "bool",
+    "desc": "Whether to use the region as a subdomain in the API URL. If false, the region will be a query parameter.",
+    "val": "true"
+  },
   "maxConcurrentRequests": {
     "type": "int",
     "desc": "Maximum number of concurrent requests allowed.",

--- a/src/Camille.RiotGames/gen/configspec.json
+++ b/src/Camille.RiotGames/gen/configspec.json
@@ -8,11 +8,6 @@
     "desc": "URL to call for the Riot Games API.",
     "val": "\"api.riotgames.com\""
   },
-  "apiRegionAsSubdomain": {
-    "type": "bool",
-    "desc": "Whether to use the region as a subdomain in the API URL. If false, the region will be a query parameter.",
-    "val": "true"
-  },
   "maxConcurrentRequests": {
     "type": "int",
     "desc": "Maximum number of concurrent requests allowed.",

--- a/src/Camille.RiotGames/gen/configspec.json
+++ b/src/Camille.RiotGames/gen/configspec.json
@@ -11,7 +11,7 @@
   "apiCallRegionConfig": {
     "type": "RegionConfig",
     "desc": "How the API call should include the region.",
-    "val": "RegionConfig.inUrlAsSubdomain"
+    "val": "RegionConfig.InUrlAsSubdomain"
   },
   "regionHeaderKey": {
     "type": "string",

--- a/src/Camille.RiotGames/gen/configspec.json
+++ b/src/Camille.RiotGames/gen/configspec.json
@@ -5,7 +5,7 @@
   },
   "apiUrl": {
     "type": "string",
-    "desc": "URL to call for the Riot Games API. Include {0} for the region, if you want it in the URL - Not necessary for RegionConfig.inUrlAsRegionQueryParameter.",
+    "desc": "URL to call for the Riot Games API. Include {0} for the region, if you want it in the URL - Not necessary for RegionConfig.InUrlAsRegionQueryParameter.",
     "val": "\"{0}.api.riotgames.com\""
   },
   "apiCallRegionConfig": {

--- a/src/Camille.RiotGames/gen/configspec.json
+++ b/src/Camille.RiotGames/gen/configspec.json
@@ -5,7 +5,7 @@
   },
   "apiUrl": {
     "type": "string",
-    "desc": "URL to call for the Riot Games API. Include {0} for the region, if you want it in the URL - Not necessary for RegionConfig.InUrlAsRegionQueryParameter.",
+    "desc": "URL to call for the Riot Games API. Include {0} for the region, if you want it in the URL - Not necessary if apiCallRegionConfig is RegionConfig.InUrlAsRegionQueryParameter.",
     "val": "\"{0}.api.riotgames.com\""
   },
   "apiCallRegionConfig": {

--- a/src/Camille.RiotGames/gen/configspec.json
+++ b/src/Camille.RiotGames/gen/configspec.json
@@ -13,9 +13,9 @@
     "desc": "How the API call should include the region.",
     "val": "RegionConfig.InUrlAsSubdomain"
   },
-  "regionHeaderKey": {
+  "regionKey": {
     "type": "string",
-    "desc": "The header key to use for the region. Only used if RegionConfig is set to inHeader.",
+    "desc": "The query or header name to use for the region. Only used if RegionConfig is set to InHeader or InUrlAsRegionQueryParameter.",
     "val": "\"Riot-Region\""
   },
   "maxConcurrentRequests": {

--- a/src/Camille.RiotGames/src/Enums/RegionConfig.cs
+++ b/src/Camille.RiotGames/src/Enums/RegionConfig.cs
@@ -1,0 +1,18 @@
+﻿// MobaHinted Copyright (C) 2024 Ethan Henderson <ethan@zbee.codes>
+// Licensed under GPLv3 - Refer to the LICENSE file for the complete text
+
+namespace Camille.RiotGames.Enums
+{
+    public enum RegionConfig
+    {
+        /// <summary>The Region should be in the URL, as a subdomain</summary>
+        InUrlAsSubdomain,
+
+        /// <summary>The Region should be in the URL, as a query parameter</summary>
+        InUrlAsRegionQueryParameter,
+
+        /// <summary>The Region should be a header instead of in the URL</summary>
+        /// <seealso cref="RiotGamesApiConfig.RegionHeaderKey"/>
+        InHeader,
+    }
+}

--- a/src/Camille.RiotGames/src/Enums/RegionConfig.cs
+++ b/src/Camille.RiotGames/src/Enums/RegionConfig.cs
@@ -1,7 +1,4 @@
-﻿// MobaHinted Copyright (C) 2024 Ethan Henderson <ethan@zbee.codes>
-// Licensed under GPLv3 - Refer to the LICENSE file for the complete text
-
-namespace Camille.RiotGames.Enums
+﻿namespace Camille.RiotGames.Enums
 {
     public enum RegionConfig
     {

--- a/src/Camille.RiotGames/src/Enums/RegionConfig.cs
+++ b/src/Camille.RiotGames/src/Enums/RegionConfig.cs
@@ -9,7 +9,7 @@
         InUrlAsRegionQueryParameter,
 
         /// <summary>The Region should be a header instead of in the URL</summary>
-        /// <seealso cref="RiotGamesApiConfig.RegionHeaderKey"/>
+        /// <seealso cref="RiotGamesApiConfig.RegionKey"/>
         InHeader,
     }
 }

--- a/src/Camille.RiotGames/src/Util/RegionalRequester.cs
+++ b/src/Camille.RiotGames/src/Util/RegionalRequester.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Camille.Core;
 using Camille.Enums;
+using Camille.RiotGames.Enums;
 
 namespace Camille.RiotGames.Util
 {
@@ -47,7 +48,7 @@ namespace Camille.RiotGames.Util
             _region = route;
 
             // If the region is to be used in the url as a subdomain
-            if (_config.ApiCallRegionConfig == RegionConfig.inUrlAsSubdomain)
+            if (_config.ApiCallRegionConfig == RegionConfig.InUrlAsSubdomain)
             {
                 _client.BaseAddress = new Uri(string.Format($"https://{config.ApiUrl}", route));
             }
@@ -63,7 +64,7 @@ namespace Camille.RiotGames.Util
             }
 
             // The header for the region, if requested
-            if (_config.ApiCallRegionConfig == RegionConfig.inHeader)
+            if (_config.ApiCallRegionConfig == RegionConfig.InHeader)
             {
                 _client.DefaultRequestHeaders.Add(config.RegionHeaderKey, route);
             }
@@ -98,7 +99,7 @@ namespace Camille.RiotGames.Util
             var num5xxs = 0;
 
             // If the region is not being used as a subdomain
-            if (_config.ApiCallRegionConfig == RegionConfig.inUrlAsRegionQueryParameter)
+            if (_config.ApiCallRegionConfig == RegionConfig.InUrlAsRegionQueryParameter)
             {
                 // Append the region as a query parameter, with consideration for other parameters
                 var uri = request.RequestUri

--- a/src/Camille.RiotGames/src/Util/RegionalRequester.cs
+++ b/src/Camille.RiotGames/src/Util/RegionalRequester.cs
@@ -53,8 +53,7 @@ namespace Camille.RiotGames.Util
 
             // If the API key is empty, or the API URL does not contain riot, or if specified:
             // then the region needs to be appended to the route instead of used as a subdomain
-            if (string.IsNullOrEmpty(config.ApiKey) || !_config.ApiURL.Contains("riot") ||
-                !_config.ApiRegionAsSubdomain)
+            if (string.IsNullOrEmpty(config.ApiKey) || !_config.ApiURL.Contains("riot"))
             {
                 _client.BaseAddress = new Uri($"https://{_config.ApiURL}");
                 _regionAsSubdomain = false;

--- a/src/Camille.RiotGames/src/Util/RegionalRequester.cs
+++ b/src/Camille.RiotGames/src/Util/RegionalRequester.cs
@@ -55,17 +55,15 @@ namespace Camille.RiotGames.Util
             // then the region needs to be appended to the route instead of used as a subdomain
             if (string.IsNullOrEmpty(config.ApiKey) || !_config.ApiURL.Contains("riot"))
             {
-                _client.BaseAddress = new Uri($"https://{_config.ApiURL}");
-                _regionAsSubdomain = false;
+                _client.BaseAddress = new Uri(string.Format($"https://{config.ApiUrl}", route));
             }
             else
             {
-                _client.BaseAddress = new Uri($"https://{route}.{_config.ApiURL}");
-                _regionAsSubdomain = true;
+                _client.BaseAddress = new Uri(string.Format($"https://{config.ApiUrl}", ""));
             }
 
             // The API key is only needed for riot's API, otherwise it is assumed to be a keyed proxy
-            if (_config.ApiURL.Contains("riot"))
+            if (_config.ApiUrl.Contains("riotgames.com"))
             {
                 _client.DefaultRequestHeaders.Add(RiotKeyHeader, config.ApiKey);
             }

--- a/src/Camille.RiotGames/src/Util/RegionalRequester.cs
+++ b/src/Camille.RiotGames/src/Util/RegionalRequester.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 using Camille.Core;
 using Camille.Enums;
 using Camille.RiotGames.Enums;
@@ -98,12 +99,13 @@ namespace Camille.RiotGames.Util
             // If the region is not being used as a subdomain
             if (_config.ApiCallRegionConfig == RegionConfig.InUrlAsRegionQueryParameter)
             {
-                // Append the region as a query parameter, with consideration for other parameters
-                var uri = request.RequestUri
-                          + (!request.RequestUri.ToString().Contains("?") ? "?" : "&")
-                          + $"{_config.RegionKey}={_region}";
+                // Append the region as a query parameter
+                var uri = new UriBuilder(_client.BaseAddress.Scheme + "://" + _client.BaseAddress.Host + request.RequestUri);
+                var query = HttpUtility.ParseQueryString(uri.Query);
+                query[_config.RegionKey] = _region;
+                uri.Query = query.ToString();
                 // Replace the request with a new one that has the region correctly appended
-                request = new HttpRequestMessage(request.Method, uri);
+                request = new HttpRequestMessage(request.Method, uri.ToString());
             }
 
             for (; retries <= _config.Retries; retries++)

--- a/src/Camille.RiotGames/src/Util/RegionalRequester.cs
+++ b/src/Camille.RiotGames/src/Util/RegionalRequester.cs
@@ -66,7 +66,7 @@ namespace Camille.RiotGames.Util
             // The header for the region, if requested
             if (_config.ApiCallRegionConfig == RegionConfig.InHeader)
             {
-                _client.DefaultRequestHeaders.Add(config.RegionHeaderKey, route);
+                _client.DefaultRequestHeaders.Add(config.RegionKey, route);
             }
 
             // The API key is only needed for riot's API, otherwise it is assumed to be a keyed proxy
@@ -104,7 +104,7 @@ namespace Camille.RiotGames.Util
                 // Append the region as a query parameter, with consideration for other parameters
                 var uri = request.RequestUri
                           + (!request.RequestUri.ToString().Contains("?") ? "?" : "&")
-                          + $"region={_region}";
+                          + $"{_config.RegionKey}={_region}";
                 // Replace the request with a new one that has the region correctly appended
                 request = new HttpRequestMessage(request.Method, uri);
             }

--- a/src/Camille.RiotGames/src/Util/RegionalRequester.cs
+++ b/src/Camille.RiotGames/src/Util/RegionalRequester.cs
@@ -69,11 +69,8 @@ namespace Camille.RiotGames.Util
                 _client.DefaultRequestHeaders.Add(config.RegionKey, route);
             }
 
-            // The API key is only needed for riot's API, otherwise it is assumed to be a keyed proxy
-            if (_config.ApiUrl.Contains("riotgames.com"))
-            {
-                _client.DefaultRequestHeaders.Add(RiotKeyHeader, config.ApiKey);
-            }
+            // Include the API key (accepts "" for use with keyed proxies)
+            _client.DefaultRequestHeaders.Add(RiotKeyHeader, config.ApiKey);
         }
 
         /// <summary>

--- a/tests/Camille.RiotGames.Test/ApiComboFeaturedGamesSummonerCurrentGameV4Test.cs
+++ b/tests/Camille.RiotGames.Test/ApiComboFeaturedGamesSummonerCurrentGameV4Test.cs
@@ -79,8 +79,8 @@ namespace Camille.RiotGames.Test
                 foreach (var player in gameInfo.Participants)
                 {
                     Assert.IsNotNull(player);
-                    Assert.IsNotNull(player.SummonerName);
-                    Assert.IsTrue(player.SummonerName.Length > 0);
+                    Assert.IsNotNull(player.Puuid);
+                    Assert.IsTrue(player.Puuid.Length > 0);
                     Assert.IsFalse(player.Bot);
                 }
                 Assert.IsTrue(gameInfo.GameId > 0);


### PR DESCRIPTION
(Maintainer's note: moved and merged via #108)

I added support for custom domains in `ApiConfig`, with the region appended as a query parameter, and provided an example in the ReadMe.

All behavior is the same if you don't pass a custom domain, but otherwise it forms the called URLs with your custom domain + the endpoint + the region as a query parameter (with consideration to the few endpoints that have parameters already).
This fits [the recommended proxy](https://hextechdocs.dev/using-cloudflare-workers-to-make-api-calls/) format.

Finally, I also updated the ReadMe's example code to use the the correct `ApiConfig` and `GetChampionMasteries`.

(apologies for the ReadMe entire change, it matched line-endings on commit)