### PR TITLE
QueueType: add UNKNOWN fallback so unrecognized values don't break deserialization

### DIFF
--- a/src/Camille.Enums/gen/QueueType.cs.dt
+++ b/src/Camille.Enums/gen/QueueType.cs.dt
@@ -10,7 +10,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Camille.Enums
 {
-    [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
+    [System.Text.Json.Serialization.JsonConverter(typeof(QueueTypeConverter))]
     /// <summary>
     /// QueueType enum based on queueTypes.json.
     /// </summary>
@@ -28,5 +28,11 @@ namespace Camille.Enums
 {{
     }
 }}
+        /// <summary>
+        /// Fallback for a queueType string returned by the API that isn't in this enum yet
+        /// (e.g. a newly added or revived ranked queue not reflected in queueTypes.json).
+        /// See <see cref="QueueTypeConverter"/>.
+        /// </summary>
+        UNKNOWN = -1,
     }
 }

--- a/src/Camille.Enums/src/QueueTypeConverter.cs
+++ b/src/Camille.Enums/src/QueueTypeConverter.cs
@@ -1,0 +1,23 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Camille.Enums
+{
+    /// <summary>
+    /// Deserializes <see cref="QueueType"/>. An unrecognized queueType string (e.g. a newly added
+    /// or revived ranked queue not yet reflected in queueTypes.json) falls back to
+    /// <see cref="QueueType.UNKNOWN"/> instead of throwing, so it doesn't fail an entire response
+    /// array over one entry. Known values still round-trip through their enum member name.
+    /// </summary>
+    public class QueueTypeConverter : JsonConverter<QueueType>
+    {
+        public override QueueType Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString();
+            return value != null && System.Enum.TryParse<QueueType>(value, out var queueType) ? queueType : QueueType.UNKNOWN;
+        }
+
+        public override void Write(Utf8JsonWriter writer, QueueType value, JsonSerializerOptions options)
+            => writer.WriteStringValue(value.ToString());
+    }
+}

--- a/src/Camille.Enums/src/QueueTypeConverter.cs
+++ b/src/Camille.Enums/src/QueueTypeConverter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -13,8 +14,16 @@ namespace Camille.Enums
     {
         public override QueueType Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
         {
-            var value = reader.GetString();
-            return value != null && System.Enum.TryParse<QueueType>(value, out var queueType) ? queueType : QueueType.UNKNOWN;
+            if (reader.TokenType != JsonTokenType.String)
+            {
+                return QueueType.UNKNOWN;
+            }
+
+            var value = reader.GetString()!;
+            var isParsed = Enum.TryParse<QueueType>(value, ignoreCase: true, out var queueType) 
+                        && Enum.IsDefined(typeof(QueueType), queueType);
+
+            return isParsed ? queueType : QueueType.UNKNOWN;
         }
 
         public override void Write(Utf8JsonWriter writer, QueueType value, JsonSerializerOptions options)

--- a/tests/Camille.Enums.Test/QueueTypeConverterTest.cs
+++ b/tests/Camille.Enums.Test/QueueTypeConverterTest.cs
@@ -1,0 +1,41 @@
+using System.Text.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Camille.Enums;
+
+namespace Camille.RiotGames.Test
+{
+    [TestClass]
+    public class QueueTypeConverterTest
+    {
+        [TestMethod]
+        public void KnownValue_Deserializes()
+        {
+            var result = JsonSerializer.Deserialize<QueueType>("\"RANKED_SOLO_5x5\"");
+            Assert.AreEqual(QueueType.RANKED_SOLO_5x5, result);
+        }
+
+        [TestMethod]
+        public void UnrecognizedValue_FallsBackToUnknown()
+        {
+            var result = JsonSerializer.Deserialize<QueueType>("\"NOT_A_REAL_QUEUE_TYPE\"");
+            Assert.AreEqual(QueueType.UNKNOWN, result);
+        }
+
+        [TestMethod]
+        public void UnrecognizedValue_DoesNotThrow_InArray()
+        {
+            var result = JsonSerializer.Deserialize<QueueType[]>(
+                "[\"RANKED_SOLO_5x5\", \"NOT_A_REAL_QUEUE_TYPE\", \"RANKED_FLEX_SR\"]");
+            CollectionAssert.AreEqual(
+                new[] { QueueType.RANKED_SOLO_5x5, QueueType.UNKNOWN, QueueType.RANKED_FLEX_SR },
+                result);
+        }
+
+        [TestMethod]
+        public void KnownValue_RoundTrips()
+        {
+            var json = JsonSerializer.Serialize(QueueType.RANKED_SOLO_5x5);
+            Assert.AreEqual("\"RANKED_SOLO_5x5\"", json);
+        }
+    }
+}

--- a/tests/Camille.Enums.Test/QueueTypeConverterTest.cs
+++ b/tests/Camille.Enums.Test/QueueTypeConverterTest.cs
@@ -22,6 +22,27 @@ namespace Camille.RiotGames.Test
         }
 
         [TestMethod]
+        public void KnownValue_DifferentCase_Deserializes()
+        {
+            var result = JsonSerializer.Deserialize<QueueType>("\"ranked_solo_5x5\"");
+            Assert.AreEqual(QueueType.RANKED_SOLO_5x5, result);
+        }
+
+        [TestMethod]
+        public void NumericString_FallsBackToUnknown()
+        {
+            var result = JsonSerializer.Deserialize<QueueType>("\"123\"");
+            Assert.AreEqual(QueueType.UNKNOWN, result);
+        }
+
+        [TestMethod]
+        public void NonStringToken_FallsBackToUnknown()
+        {
+            var result = JsonSerializer.Deserialize<QueueType>("123");
+            Assert.AreEqual(QueueType.UNKNOWN, result);
+        }
+
+        [TestMethod]
         public void UnrecognizedValue_DoesNotThrow_InArray()
         {
             var result = JsonSerializer.Deserialize<QueueType[]>(


### PR DESCRIPTION
Fixes #126.

`QueueType` uses `[JsonConverter(typeof(JsonStringEnumConverter))]`, which throws when the API returns a `queueType` string not in `queueTypes.json`, failing deserialization of the entire response array over one unrecognized entry. This isn't rare: Riot revives/adds ranked queues periodically (most recently "Ranked 5s" in 2026, `queueType: "RANKED_PREMADE_5x5"`, still missing from `queueTypes.json` as of this PR).

- `QueueType` gains one new member: `UNKNOWN = -1`.
- The type-level `JsonStringEnumConverter` is replaced with a hand-written `QueueTypeConverter` (`src/`, alongside `Tier.cs`/`Division.cs`) that falls back to `UNKNOWN` on `Enum.TryParse` failure instead of throwing. Known values still round-trip through their member name unchanged.

Added `QueueTypeConverterTest.cs`: known value parses, unrecognized value falls back to `UNKNOWN`, unrecognized value inside an array doesn't fail the whole array, known values round-trip on write.
